### PR TITLE
Fixed Unsupported Media Type issue during upload

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -17,7 +17,7 @@ gradlePlugin {
     plugins {
         simplePlugin {
             id = 'com.teamwanari.appcenter-publish-plugin'
-            version = '0.0.2'
+            version = '0.0.3'
             displayName = 'AppCenterPlugin'
             description = 'Uploads selected artifacts to AppCenter.'
             implementationClass = 'com.teamwanari.appcenter.AppCenterPlugin'

--- a/plugin/src/main/kotlin/com/teamwanari/appcenter/AppCenterUploadTask.kt
+++ b/plugin/src/main/kotlin/com/teamwanari/appcenter/AppCenterUploadTask.kt
@@ -109,6 +109,7 @@ open class AppCenterUploadTask : DefaultTask() {
                 .url(uploadUrl)
                 .addHeader(HEADER_CONTENT_TYPE, MEDIA_TYPE_MULTI_FORM)
                 .post(MultipartBody.Builder()
+                        .setType(MultipartBody.FORM)
                         .addFormDataPart(PART_KEY_ARTIFACT, config.artifact.name,
                                 RequestBody.create(
                                         MediaType.parse(MEDIA_TYPE_OCTET),


### PR DESCRIPTION
Over the last few days I got `Unsupported Media Type` on uploading the artifact, only occasionally the upload would successfully complete.
After some investigations and some tests it looks like this change could solve the issue - I tested the plugin publishing to the local maven repository and seems to work correctly.
I also updated the version for simplicity.

Any comment/improvement is welcomed!